### PR TITLE
:recycle: Fix: 공통응답포맷 수정

### DIFF
--- a/src/main/java/com/example/delivery/common/response/ApiResponseDto.java
+++ b/src/main/java/com/example/delivery/common/response/ApiResponseDto.java
@@ -24,10 +24,10 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
  */
 @Builder
 public record ApiResponseDto<T>( // record: dto를 간결하게 작성하는 방식으로 생성자/getter/equals 를 자동으로 만들어줌, 불변객체임
-                                 LocalDateTime timestamp,                       // 요청 시각
+                                 @JsonInclude(NON_NULL) LocalDateTime timestamp,                       // 요청 시각
                                  int statusCode,                                // HTTP 상태 코드 숫자 (예: 400)
                                  @NonNull String message,                       // 응답 메시지 (ex: "가게 생성 성공", "잘못된 요청입니다")
-                                 String path,                                   // 요청 경로 (ex : api/stores)
+                                 @JsonInclude(value = NON_NULL)String path,                                   // 요청 경로 (ex : api/stores)
                                  @JsonInclude(value = NON_NULL) T data          // 실제 응답 데이터 (nullable), null이면 JSON에서 제외됨
 ) {
     /**
@@ -35,27 +35,27 @@ public record ApiResponseDto<T>( // record: dto를 간결하게 작성하는 방
      * 예를 들면 가게 생성을 성공했을 때, 데이터도 함께 내려주고 싶을 때 사용함
      * @param successCode 성공 상태코드/메시지 Enum
      * @param data 응답 데이터
-     * @param path 요청 경로
      * @return ApiResponseDto
      */
-    public static <T> ApiResponseDto<T> success(final SuccessCode successCode, @Nullable final T data, final String path) {
-        return ApiResponseDto.<T>builder()
-                .timestamp(LocalDateTime.now())
-                .statusCode(successCode.getHttpStatus().value())
-                .message(successCode.getMessage())
-                .path(path)
-                .data(data)
-                .build();
+    public static <T> ApiResponseDto<T> success(final SuccessCode successCode,
+                                                @Nullable final T data
+                                                ) {
+        return new ApiResponseDto<>(
+                null,
+                successCode.getHttpStatus().value(),
+                successCode.getMessage(),
+                null,
+                data
+        );
     }
     /**
      * 성공 응답을 생성하는 메소드 (데이터 X)
      * 예를 들면 로그아웃에 성공했습니다 -> 따로 줄 데이터가 없음
      * @param successCode 성공 상태코드/메시지 Enum
-     * @param path 요청 경로
      * @return ApiResponseDto
      */
-    public static <T> ApiResponseDto<T> success(final SuccessCode successCode, final String path) {
-        return success(successCode, null, path);
+    public static <T> ApiResponseDto<T> success(final SuccessCode successCode) {
+        return success(successCode, null);
     }
     /**
      * 실패 응답을 생성하는 메소드 (ErrorCode 기반)
@@ -65,13 +65,13 @@ public record ApiResponseDto<T>( // record: dto를 간결하게 작성하는 방
      * @return ApiResponseDto
      */
     public static <T> ApiResponseDto<T> fail(final ErrorCode errorCode, final String path) {
-        return ApiResponseDto.<T>builder()
-                .timestamp(LocalDateTime.now())
-                .statusCode(errorCode.getHttpStatus().value())
-                .message(errorCode.getMessage())
-                .path(path)
-                .data(null)
-                .build();
+        return new ApiResponseDto<>(
+                LocalDateTime.now(),
+                errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                path,
+                null
+        );
     }
 
     /**
@@ -82,12 +82,12 @@ public record ApiResponseDto<T>( // record: dto를 간결하게 작성하는 방
      * @return ApiResponseDto
      */
     public static <T> ApiResponseDto<T> fail(final String message, final String path) {
-        return ApiResponseDto.<T>builder()
-                .timestamp(LocalDateTime.now())
-                .statusCode(HttpStatus.BAD_REQUEST.value())
-                .message(message)
-                .path(path)
-                .data(null)
-                .build();
+        return new ApiResponseDto<>(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                message,
+                path,
+                null
+        );
     }
 }


### PR DESCRIPTION
## 📌 ApiResponseDto 수정
- Closes #16 <!-- 연결된 이슈 번호 기재 -->



## ✨ 기능 요약

| 항목 | 내용 |
|------|------|
| 🆕 기능명 | ApiResponseDto 리팩토링 |
| 🔍 목적 | REST API 설계 원칙에 맞게 응답 포맷을 간결하게 정리하고 역할 분리 |
| 🛠️ 변경사항 | path, timestamp 필드를 조건부 포함 / 빌더 패턴 제거 |



## 📝 상세 내역

1️⃣ 성공 응답에서는 timestamp, path를 JSON에서 제외하고, 실패 응답에서만 포함되도록 처리
2️⃣ 기존의 @Builder 제거, record 기본 생성자 활용으로 간결화
3️⃣ 성공/실패 응답 메서드 정리 → 중복 오버로딩 제거 및 명확한 책임 분리



## ✅ 테스트 체크리스트
- [ ] 성공 응답 시 data, statusCode, message만 포함되는지 확인
- [ ] 실패 응답 시 timestamp, path가 JSON에 포함되는지 확인
- [ ] 기존 기능과의 호환성 확인 (SuccessCode, ErrorCode 연동 정상)


## 📸 포스트맨 캡처 사진


---

## 🙋‍♀️ 리뷰어 참고사항
아래 댓글 확인 부탁드립니다 !!!! 
